### PR TITLE
fix(test-pulse-stack): drop the orphaned readability guard in at_time

### DIFF
--- a/neuroanalysis/test_pulse_stack.py
+++ b/neuroanalysis/test_pulse_stack.py
@@ -100,8 +100,6 @@ class H5BackedTestPulseStack:
 
     def at_time(self, when: float) -> PatchClampTestPulse | None:
         """Return the test pulse at or immediately previous to the provided time."""
-        if not self._readable:
-            raise ValueError("This stack is not readable")
         keys = self._np_timestamp_cache
         idx = np.searchsorted(keys, when)
         if idx == 0:


### PR DESCRIPTION
## What changed

Removed a two-line guard at the top of `H5BackedTestPulseStack.at_time` that tested `self._readable`, an attribute that no longer exists.

## Why

`dc99933` ("unreadable is unnecessary: we have lazy load") removed the `readable` constructor argument, the `self._readable` assignment, and the corresponding guards in `__getitem__`, `merge`, and `__len__` — but missed the one in `at_time`. Every call through `at_time` therefore raised:

```
AttributeError: 'H5BackedTestPulseStack' object has no attribute '_readable'
```

This surfaced in acq4's multipatch log viewer, whose `MultiPatchLogWidget.testPulsesAtTime` is the only caller: moving the time slider raised as soon as the full-test-pulse plot was enabled, so full test pulses could not be displayed at all.

## Notes for reviewers

- `_readable` now has zero references anywhere in the repo, so this completes `dc99933`'s intent rather than reinstating removed behavior.
- `neuroanalysis/tests/test_test_pulse.py::test_bath_ugly` already covered this path and was failing with exactly the AttributeError above; it passes now, as do `test_append_stack` and `test_load`. No new test was needed.
- Verified end-to-end against a real acq4 log (340 test pulses): built `MultiPatchLogWidget`, enabled the full-test-pulse plot, and stepped `setTime` across 21 points spanning the log — no exceptions, test pulses resolved at every point.

## Out of scope

`at_time` uses `np.searchsorted` on `_np_timestamp_cache`, which is built from h5py group iteration order (lexicographic on stringified floats) and extended by `merge`/`append` without re-sorting. It happens to be sorted for the files tested here, but it is a latent wrong-pulse bug for timestamp strings of differing length or for merged stacks. Left for a separate change.

🤖 Generated with [Claude Code](https://claude.ai/code)